### PR TITLE
Support Projection Typing

### DIFF
--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -50,7 +50,7 @@ export class MongoRepository<DOC, DTO = DOC> {
    * Find multiple documents by a list of ids
    *
    * @param {string[]} ids
-   * @returns {Promise<T[]>}
+   * @returns {Promise<DOC[]>}
    * @memberof MongoRepository
    */
   async findManyById(ids: string[]): Promise<DOC[]> {
@@ -90,10 +90,10 @@ export class MongoRepository<DOC, DTO = DOC> {
    * Find records by a list of conditions
    *
    * @param {FindRequest} [req={ conditions: {} }]
-   * @returns {Promise<T[]>}
+   * @returns {Promise<PROJECTION[]>}
    * @memberof MongoRepository
    */
-  async find(req: FindRequest = { conditions: {} }): Promise<DOC[]> {
+  async find<PROJECTION = DOC>(req: FindRequest = { conditions: {} }): Promise<PROJECTION[]> {
     const collection = await this.collection;
 
     const conditions = this.toggleId(req.conditions, true);
@@ -278,10 +278,10 @@ export class MongoRepository<DOC, DTO = DOC> {
    * @private
    * @param {*} document
    * @param {boolean} replace
-   * @returns {T}
+   * @returns {any}
    * @memberof MongoRepository
    */
-  protected toggleId(document: any, replace: boolean): DOC {
+  protected toggleId(document: any, replace: boolean): any {
     if (document && (document.id || document._id)) {
       if (replace) {
         document._id = new ObjectID(document.id);
@@ -302,7 +302,7 @@ export class MongoRepository<DOC, DTO = DOC> {
    * @param {RepoOperation[]} fns any of the valid functions: update, updateOne, save, create, find, findOne, findMany
    * @param {*} newDocument The document to apply functions to
    * @param {*} oldDocument The original document before changes were applied
-   * @returns {Promise<DOC>}
+   * @returns {Promise<any>}
    * @memberof MongoRepository
    */
   protected async invokeEvents(


### PR DESCRIPTION
Updated Repository.find() to support an optional type override for projections

Now you can do support providing a type for a projection like this:

```typescript

interface Person {
  name: string;
  email: string;
  phone: string;
}

class PersonRepository extends MongoRepository<Person> {}

const repo = new PersonRepository(db);

const justEmail = await repo.find<{ email: string; }>({ conditions: {}, projection: { 'email': 1}});

// or if you want to get really fancy

const fancyJustEmail = await repo.find<Pick<Person, 'email'>>({ conditions: {}, projection: { 'email': 1}});

```