### PR TITLE
Enforce intended 'Document' and 'DTO' relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ MongoDB Repository pattern for NodeJS written in TypeScript.
 
 ## Usage
 
-[Migrating from 2.X to 3.X](UPGRADE.md)
-[Migrating from 1.X to 2.X](UPGRADE.md)
+### Upgrade Guide
+
+- [Migrating from 4.X to 5.X](UPGRADE.md)
+- [Migrating from 3.X to 4.X](UPGRADE.md)
+- [Migrating from 2.X to 3.X](UPGRADE.md)
+- [Migrating from 1.X to 2.X](UPGRADE.md)
 
 ### DatabaseClient
 
@@ -37,38 +41,46 @@ dbc.connect(uri, mongoClient);
 
 ### Using DI
 
-```javascript
-import { MongoRepository, Collection, Pre, Post } from 'mongtype';
-import { Injectable } from 'injection-js';
+```typescript
+import {MongoRepository, Collection, Pre, Post} from 'mongtype';
+import {Injectable} from 'injection-js';
+import {ObjectID} from "mongodb";
 
-interface User {
-  name: string;
+interface UserDTO {
+    name: string;
+}
+
+interface UserDocument extends UserDTO {
+    id: string | ObjectID;
 }
 
 @Injectable()
 @Collection({
-  name: 'user',
-  capped: true,
-  size: 10000
+    name: 'user',
+    capped: true,
+    size: 10000
 })
-export class UserRepository extends MongoRepository<User> {
-  @Before('save')
-  doSomethingBeforeSave() {}
+export class UserRepository extends MongoRepository<UserDocument, UserDTO> {
+    @After('create')
+    doSomethingAfterCreate() {
+    }
 
-  @After('save')
-  doSomethingAfterSave() { }
+    @Before('save')
+    doSomethingBeforeSave() {
+    }
 }
 
 @Injectable()
 export class App {
-  constructor(private userRepo: UserRepository) { }
+    constructor(private userRepo: UserRepository) {
+    }
 
-  async findUsers() {
-    const one = await this.userRepo.findById('3434-34-34343-3434');
-    const many = await this.userRepo.find({ conditions: { name: 'foo' } });
-    const newOne = await this.userRepo.create({ foo: true });
-    const updated = await this.userRepo.save(newOne);
-  }
+    async findUsers() {
+        const one = await this.userRepo.findById('3434-34-34343-3434');
+        const many = await this.userRepo.find({conditions: {name: 'foo'}});
+        const newOne = await this.userRepo.create({foo: true});
+        const updated = await this.userRepo.save(newOne);
+    }
 }
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,14 @@
 # Upgrade Guide
 
+## 4.x to 5.x Upgrade Guide
+
+The `MongoRepository` class now requires two type parameters.
+
+- The first param `DOC` is short for "Document" and represents the shape of a document as stored in Mongo, including an `id` member.
+- The second type param `DTO` stands for "DTO" and represents the shape of a document during transfer to/from Mongo.
+
+`DTO` SHOULD not have an `id` member because the document may not yet exist in Mongo. `DOC` MUST be a superset of `DTO` and MUST include an `id` member of type `string | ObjectId`.
+
 ## 3.x to 4.x Upgrade Guide
 
 Update to Database Client to allow users to provide `MongoClientOptions` to `DatabaseClient.connect()`. This changes the argument order so it's not backwards compatible with Mongtype 3.x

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,6 @@
 # Upgrade Guide
 
-## 4.x to 5.x Upgrade Guide
+## 7.x Upgrade Guide
 
 The `MongoRepository` class now requires two type parameters.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,6 +9,8 @@ The `MongoRepository` class now requires two type parameters.
 
 `DTO` SHOULD not have an `id` member because the document may not yet exist in Mongo. `DOC` MUST be a superset of `DTO` and MUST include an `id` member of type `string | ObjectId`.
 
+See [Repository tests](./tests/Repository.spec.ts) for examples.
+
 ## 3.x to 4.x Upgrade Guide
 
 Update to Database Client to allow users to provide `MongoClientOptions` to `DatabaseClient.connect()`. This changes the argument order so it's not backwards compatible with Mongtype 3.x

--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -17,16 +17,17 @@ import {
   EventOptions
 } from './Types';
 
-export class MongoRepository<DOC, DTO = DOC> {
+export class MongoRepository<DOC extends DTO & Document, DTO extends object> {
   collection: Promise<Collection<DOC>>;
   readonly options: CollectionProps;
 
-  // get options(): CollectionProps {
-  //   return Reflect.getMetadata(COLLECTION_KEY, this);
-  // }
-
   /**
    * Creates an instance of MongoRepository.
+   *
+   * The first type parameter DOC is short for "Document" and represents the shape of a document as stored in Mongo,
+   * including an `id` member. The second type param DTO stands for "DTO" and represents the shape of a document during
+   * transfer to/from Mongo. DTO should not have an `id` member because the document may not yet exist in Mongo.
+   *
    * @param {DBSource} dbSource Your MongoDB connection
    * @param opts Collection initialize options
    * @memberof MongoRepository
@@ -133,9 +134,9 @@ export class MongoRepository<DOC, DTO = DOC> {
   }
 
   /**
-   * Create a document of type T
+   * Create a document
    *
-   * @param {DTO} document
+   * @param {DTO} document A document transfer object
    * @returns {Promise<DOC>}
    * @memberof MongoRepository
    */

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -49,7 +49,7 @@ export interface IndexDefinition {
 }
 
 export interface Document {
-  id?: string | ObjectID;
+  id: string | ObjectID;
   [key: string]: any;
 }
 


### PR DESCRIPTION
- Require both Document and DTO as type params when creating a `MongoRepository`
- Update tests
- Update user documentation
- Add a migration guide, since this is a breaking change

Fixes #35.